### PR TITLE
Do not add dot at the end of a link to the href

### DIFF
--- a/src/RichText.vue
+++ b/src/RichText.vue
@@ -31,14 +31,22 @@ const parseUrl = (text, linkComponent) => {
 	let start = 0
 	while (match !== null) {
 		let href = match[0]
+		let textAfter
 		let textBefore = text.substring(start, match.index)
 		if (href[0] === ' ' || href[0] === '(') {
 			textBefore += href[0]
-			href = href.substring(1)
+			href = href.substring(1).trim()
+		}
+		if (href[(href.length - 1)] === '.') {
+			href = href.substring(0, href.length - 1)
+			textAfter = '.'
 		}
 
 		list.push(textBefore)
-		list.push({ component: linkComponent, props: { href: href.trim() } })
+		list.push({ component: linkComponent, props: { href } })
+		if (textAfter) {
+			list.push(textAfter)
+		}
 		start = match.index + match[0].length
 		match = urlRegex.exec(text)
 	}

--- a/src/RichText.vue
+++ b/src/RichText.vue
@@ -37,9 +37,10 @@ const parseUrl = (text, linkComponent) => {
 			textBefore += href[0]
 			href = href.substring(1).trim()
 		}
-		if (href[(href.length - 1)] === '.') {
+		const lastChar = href[(href.length - 1)]
+		if (lastChar === '.' || lastChar === ',' || lastChar === ';') {
 			href = href.substring(0, href.length - 1)
-			textAfter = '.'
+			textAfter = lastChar
 		}
 
 		list.push(textBefore)


### PR DESCRIPTION
If a url ends with a `.` it will no longer be part of the link, as in almost all cases it indicates the end of a sentence instead of being part of the url.

@nickvergessen I've seen this happening quite some times in talk where it actually broke the link, what to you think about that change?