### PR TITLE
Strip trailing ')' from detected links

### DIFF
--- a/src/RichText.vue
+++ b/src/RichText.vue
@@ -38,7 +38,7 @@ const parseUrl = (text, linkComponent) => {
 			href = href.substring(1).trim()
 		}
 		const lastChar = href[(href.length - 1)]
-		if (lastChar === '.' || lastChar === ',' || lastChar === ';' || lastChar === ')') {
+		if (lastChar === '.' || lastChar === ',' || lastChar === ';' || (match[0][0] === '(' && lastChar === ')')) {
 			href = href.substring(0, href.length - 1)
 			textAfter = lastChar
 		}

--- a/src/RichText.vue
+++ b/src/RichText.vue
@@ -23,17 +23,17 @@
 <script>
 import Link from './Link'
 
-const urlRegex = /(\s|\(|^)(https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?::[0-9]+)?(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(?=\s|\)|$)/ig
+const urlRegex = /(\s|\(|^)((https?:\/\/)((?:[-A-Z0-9+_]+\.)+[-A-Z]+(?::[0-9]+)?(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*))(?=\s|\)|$)/ig
 
 const parseUrl = (text, linkComponent) => {
 	let match = urlRegex.exec(text)
 	const list = []
 	let start = 0
 	while (match !== null) {
-		let href = match[0]
+		let href = match[2]
 		let textAfter
-		let textBefore = text.substring(start, match.index)
-		if (href[0] === ' ' || href[0] === '(') {
+		let textBefore = text.substring(start, match.index + match[1].length)
+		if (href[0] === ' ') {
 			textBefore += href[0]
 			href = href.substring(1).trim()
 		}

--- a/src/RichText.vue
+++ b/src/RichText.vue
@@ -38,7 +38,7 @@ const parseUrl = (text, linkComponent) => {
 			href = href.substring(1).trim()
 		}
 		const lastChar = href[(href.length - 1)]
-		if (lastChar === '.' || lastChar === ',' || lastChar === ';') {
+		if (lastChar === '.' || lastChar === ',' || lastChar === ';' || lastChar === ')') {
 			href = href.substring(0, href.length - 1)
 			textAfter = lastChar
 		}

--- a/tests/richtext.spec.js
+++ b/tests/richtext.spec.js
@@ -101,15 +101,27 @@ describe('Foo', () => {
 	it('properly inserts a link component with brackets', async () => {
 		const wrapper = mount(RichText, {
 			propsData: {
-				text: 'Testwith a link to (https://example.com) - go visit it',
+				text: 'Test with a link to (https://example.com) - go visit it',
 				autolink: true
 			}
 		})
-		expect(wrapper.text()).toEqual('Testwith a link to (https://example.com) - go visit it')
+		expect(wrapper.text()).toEqual('Test with a link to (https://example.com) - go visit it')
 		expect(wrapper.find(Link).exists()).toBe(true)
 		expect(wrapper.find(Link).attributes('href')).toBe('https://example.com')
 	})
-	
+
+	it('properly inserts a link component with brackets around text', async () => {
+		const wrapper = mount(RichText, {
+			propsData: {
+				text: 'Test with a link to (https://example.com/) - go visit it',
+				autolink: true
+			}
+		})
+		expect(wrapper.text()).toEqual('Test with a link to (https://example.com/) - go visit it')
+		expect(wrapper.find(Link).exists()).toBe(true)
+		expect(wrapper.find(Link).attributes('href')).toBe('https://example.com/')
+	})
+
 	it('properly recognizes an url with a custom port and inserts a link component', async () => {
 		const wrapper = mount(RichText, {
 			propsData: {

--- a/tests/richtext.spec.js
+++ b/tests/richtext.spec.js
@@ -122,6 +122,18 @@ describe('Foo', () => {
 		expect(wrapper.find(Link).attributes('href')).toBe('https://example.com/')
 	})
 
+	it('properly inserts a link component ending with a bracket', async () => {
+		const wrapper = mount(RichText, {
+			propsData: {
+				text: 'Test with a link to https://example.com/) - go visit it',
+				autolink: true
+			}
+		})
+		expect(wrapper.text()).toEqual('Test with a link to https://example.com/) - go visit it')
+		expect(wrapper.find(Link).exists()).toBe(true)
+		expect(wrapper.find(Link).attributes('href')).toBe('https://example.com/)')
+	})
+
 	it('properly recognizes an url with a custom port and inserts a link component', async () => {
 		const wrapper = mount(RichText, {
 			propsData: {


### PR DESCRIPTION
`See the link (https://github.com/nextcloud/server)` should lead to 

`See the link (<a href="https://github.com/nextcloud/server">https://github.com/nextcloud/server</a>)`

instead of 

`See the link (<a href="https://github.com/nextcloud/server)">https://github.com/nextcloud/server)</a>`